### PR TITLE
feat: restrict props with type checking

### DIFF
--- a/constructs/Lambda/config.ts
+++ b/constructs/Lambda/config.ts
@@ -2,13 +2,11 @@ import { Duration } from 'aws-cdk-lib';
 import { Architecture, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunctionProps } from 'aws-cdk-lib/aws-lambda-nodejs';
 
-import { AllowedLambdaConfig } from './types';
-
-export const allowedConfig: AllowedLambdaConfig = {
+export const allowedConfig = {
   runtime: [Runtime.NODEJS_18_X],
-  architecture: Object.values(Architecture) as Architecture[],
-  tracing: Object.values(Tracing) as Tracing[],
-  retryAttempts: [0, 1, 2],
+  architecture: [Architecture.ARM_64, Architecture.X86_64],
+  tracing: [Tracing.ACTIVE] as const,
+  retryAttempts: [0, 1, 2] as const,
 };
 
 export const requiredConfig: Partial<NodejsFunctionProps> = {

--- a/constructs/Lambda/lambda.ts
+++ b/constructs/Lambda/lambda.ts
@@ -15,9 +15,10 @@ import {
   errorMessages,
   LambdaConfigurationError,
 } from './errors';
+import { AleiosLambdaProps } from './types';
 
 export class AleiosLambda extends NodejsFunction {
-  constructor(scope: Construct, id: string, props?: NodejsFunctionProps) {
+  constructor(scope: Construct, id: string, props: AleiosLambdaProps) {
     checkRequiredProperties(
       props,
       requiredConfig,

--- a/constructs/Lambda/types.ts
+++ b/constructs/Lambda/types.ts
@@ -1,8 +1,22 @@
-import { Architecture, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunctionProps } from 'aws-cdk-lib/aws-lambda-nodejs';
 
-export interface AllowedLambdaConfig {
-  runtime: Runtime[];
-  architecture: Architecture[];
-  tracing: Tracing[];
-  retryAttempts: number[];
+import { allowedConfig } from './config';
+
+export interface RestrictedLambdaConfig {
+  retryAttempts: typeof allowedConfig.retryAttempts[number];
+  tracing: typeof allowedConfig.tracing[number];
+  runtime: typeof allowedConfig.runtime[number]; //currently this doesnt restrict the runtime to nodejs
+  architecture: typeof allowedConfig.architecture[number]; //currently this doesnt restrict the architecture
+}
+
+export interface RequiredLambdaConfig extends Partial<NodejsFunctionProps> {
+  functionName: string;
+  entry: string;
+}
+
+export interface AleiosLambdaProps extends RequiredLambdaConfig {
+  runtime?: RestrictedLambdaConfig['runtime'];
+  architecture?: RestrictedLambdaConfig['architecture'];
+  tracing?: RestrictedLambdaConfig['tracing'];
+  retryAttempts?: RestrictedLambdaConfig['retryAttempts'];
 }

--- a/functions/helloWorld/config.ts
+++ b/functions/helloWorld/config.ts
@@ -1,4 +1,4 @@
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Architecture, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import { join } from 'path';
 
@@ -10,8 +10,11 @@ export class HelloWorld extends Construct {
 
     new AleiosLambda(this, 'HelloWorldLambda', {
       functionName: 'hello-world',
+      architecture: Architecture.ARM_64,
+      tracing: Tracing.PASS_THROUGH,
       entry: join(__dirname, 'handler.ts'),
-      runtime: Runtime.NODEJS_14_X,
+      runtime: Runtime.NODEJS_16_X,
+      retryAttempts: 20,
     });
   }
 }


### PR DESCRIPTION
Works for all enum types not classes. So Architecture and Runtime are still not typechecked with the allowed config.